### PR TITLE
findLeftMostPositionForItem logic is flawed

### DIFF
--- a/spec/gridCollisionsSpec.js
+++ b/spec/gridCollisionsSpec.js
@@ -223,4 +223,24 @@ describe("Grid collisions", function() {
     expectedItems[16] = {x: 9, y: 2};
     expect(grid.items).toEqualPositions(expectedItems);
   });
+
+  it("should check across the entire height of an item when searching for a " +
+     "position", function() {
+    var items = [
+      {x: 0, y: 2, w: 2, h: 2},
+      {x: 2, y: 1, w: 1, h: 2},
+      {x: 3, y: 1, w: 2, h: 2}
+    ];
+
+    var grid = new GridList(GridList.cloneItems(items), {rows: 4});
+
+    helpers.addIndexesToItems(grid.items);
+    grid.moveItemToPosition(grid.items[2], [3, 0]);
+    helpers.sortItemsByIndex(grid.items);
+
+    var expectedItems = GridList.cloneItems(items);
+    expectedItems[2].y = 0;
+
+    expect(grid.items).toEqualPositions(expectedItems);
+  });
 });

--- a/src/gridList.js
+++ b/src/gridList.js
@@ -524,14 +524,17 @@ GridList.prototype = {
      */
     var tail = 0,
         otherItem,
-        i;
+        i, j;
+
     for (i = 0; i < this.grid.length; i++) {
-      otherItem = this.grid[i][item.y];
-      if (!otherItem) {
-        continue;
-      }
-      if (this.items.indexOf(otherItem) < this.items.indexOf(item)) {
-        tail = otherItem.x + otherItem.w;
+      for (j = item.y; j < item.y + item.h; j++) {
+        otherItem = this.grid[i][j];
+        if (!otherItem) {
+          continue;
+        }
+        if (this.items.indexOf(otherItem) < this.items.indexOf(item)) {
+          tail = otherItem.x + otherItem.w;
+        }
       }
     }
     return tail;


### PR DESCRIPTION
![bug](https://cloud.githubusercontent.com/assets/12442713/9090886/a6a1e5b4-3ba5-11e5-95b7-1cb0610a1c01.gif)


## Solution

The [_findLeftMostPositionForItem](https://github.com/uberVU/grid/blob/20531d60a6900c421d310a8e43213224183ac03e/src/gridList.js#L518) method is only checking for items [on the same row](https://github.com/uberVU/grid/blob/20531d60a6900c421d310a8e43213224183ac03e/src/gridList.js#L529) as the given item. We should change it to check for items across the entire height of the item.

```js
for (var j = item.y; j < item.y + item.h; j++) {
  var otherItem = this.grid[i][j];
}
```


#### TODO

- [x] write tests that fail
- [x] fix tests
