### PR TITLE
Resizing the grid can leave empty horizontal spaces

### DIFF
--- a/spec/gridPositioningSpec.js
+++ b/spec/gridPositioningSpec.js
@@ -58,4 +58,22 @@ describe("Grid positioning", function() {
       expect(grid.items).toEqualPositions(gridFixture.rows4);
     });
   });
+
+  it("should pull to left after resizing", function() {
+    var grid = new GridList([
+      {x: 0, y: 0, w: 1, h: 1},
+      {x: 0, y: 1, w: 1, h: 1},
+      {x: 1, y: 0, w: 1, h: 2},
+      {x: 2, y: 0, w: 1, h: 1}
+    ], {rows: 2});
+
+    grid.resizeGrid(3);
+
+    expect(grid.items).toEqualPositions([
+      {x: 0, y: 0, w: 1, h: 1},
+      {x: 0, y: 1, w: 1, h: 1},
+      {x: 1, y: 0, w: 1, h: 2},
+      {x: 0, y: 2, w: 1, h: 1}
+    ]);
+  });
 });

--- a/src/gridList.js
+++ b/src/gridList.js
@@ -150,6 +150,8 @@ GridList.prototype = {
       // New items should never be placed to the left of previous items
       currentColumn = Math.max(currentColumn, item.x);
     }
+
+    this._pullItemsToLeft();
   },
 
   findPositionForItem: function(item, start, fixedRow) {


### PR DESCRIPTION
![bug2](https://cloud.githubusercontent.com/assets/12442713/9109278/18b7b948-3c3d-11e5-9ae4-70bc689da828.gif)

![bug4](https://cloud.githubusercontent.com/assets/12442713/9112069/01dddc1c-3c55-11e5-9560-d1d1f8953984.gif)


## Solution

The [resizeGrid](https://github.com/uberVU/grid/blob/20531d60a6900c421d310a8e43213224183ac03e/src/gridList.js#L134) method has a [restriction](https://github.com/uberVU/grid/blob/20531d60a6900c421d310a8e43213224183ac03e/src/gridList.js#L150-L151): it doesn't let the current item be placed before other items horizontally. That is extremely flawed since increasing the number of rows in a grid will create empty space at the bottom that can be filled with items starting with position `x: 0`.

This restriction could be removed, or can be left in place and a call to `_pullItemsToLeft` be performed after the items have been placed.

The latter seems like the right choice because:

- the restriction is in place to preserve the horizontal ordering of the items and
- the `pullToLeft` force should be applied after every operation that modifies the grid; it's the gravity of the grid and should take affect all the time.


#### TODO

- [x] write failing test
- [x] add `pullToLeft` call at the [end](https://github.com/uberVU/grid/blob/20531d60a6900c421d310a8e43213224183ac03e/src/gridList.js#L152) of the grid resize method
