### PR TITLE
Resizing an item can leave empty horizontal spaces

### DIFF
--- a/spec/gridItemResizeSpec.js
+++ b/spec/gridItemResizeSpec.js
@@ -147,4 +147,15 @@ describe("Grid item resizing", function() {
       expect(grid.items).toEqualPositions([{x: 0, y: 0}, {x: 1, y: 0}]);
     });
   });
+
+  it("should pull to left after resizing", function() {
+    var item1 = {x: 0, y: 2, w: 1, h: 1},
+        item2 = {x: 0, y: 3, w: 1, h: 1};
+
+    var grid = new GridList([item1, item2], {rows: 4});
+
+    grid.resizeItem(item2, {w: 2, h: 2});
+
+    expect(grid.items).toEqualPositions([{x: 0, y: 2}, {x: 0, y: 0}]);
+  });
 });

--- a/src/gridList.js
+++ b/src/gridList.js
@@ -224,6 +224,8 @@ GridList.prototype = {
 
     this._updateItemSize(item, width, height);
     this._resolveCollisions(item);
+
+    this._pullItemsToLeft();
   },
 
   getChangedItems: function(initialItems, idAttribute) {


### PR DESCRIPTION
![bug3](https://cloud.githubusercontent.com/assets/12442713/9111249/a87d9376-3c4d-11e5-9d6b-ed93be652a67.gif)


## Solution

When an item is resized we check if it fits in its original position. If it doesn't we start looking for a new position for it trying to preserve it's original row. If we can't find any, we make a new column and try to place it on its original row. If it doesn't fit there, we [place it on the first row](https://github.com/uberVU/grid/blob/20531d60a6900c421d310a8e43213224183ac03e/src/gridList.js#L193-L203).

However, there might be horizontal to the left of the new position. We need to call gravity to fix this. See #65 for extra details.


#### TODO

- [x] writing failing test
- [x] call `pullToLeft` [after](https://github.com/uberVU/grid/blob/20531d60a6900c421d310a8e43213224183ac03e/src/gridList.js#L224) the item is resized
