### PR TITLE
Make sure autoHeight attr is only applied on init #67

### DIFF
--- a/spec/cloneItemsSpec.js
+++ b/spec/cloneItemsSpec.js
@@ -1,0 +1,55 @@
+// Load dependencies when run with Node (in browser they are expected to
+// already be included)
+if (typeof(require) == 'function') {
+  var GridList = require('../src/gridList.js'),
+      fixtures = require('./fixtures.js');
+      matchers = require('./matchers.js');
+      helpers = require('./helpers.js');
+}
+
+
+describe("Grid cloneItems", function() {
+  it("should clone items into an empty destination", function() {
+    var items = [{}, {}, {}],
+        dest = [];
+
+    GridList.cloneItems(items, dest);
+
+    expect(dest.length).toEqual(items.length);
+  });
+
+  it("should clone all the source properties", function() {
+    var items = [{foo: 'bar', 54: 21}],
+        dest = [];
+
+    GridList.cloneItems(items, dest);
+
+    expect(dest).toEqual(items);
+  });
+
+  it("should return the destination", function() {
+    var items = [{}, {}, {}],
+        dest = [];
+
+    var ret = GridList.cloneItems(items, dest);
+
+    expect(ret).toEqual(dest);
+  });
+
+  it("should create the destination if it doesn't exist", function() {
+    var items = [{}, {}, {}];
+
+    var ret = GridList.cloneItems(items);
+
+    expect(ret).toEqual(items);
+  });
+
+  it("should overwrite existing properties when copying", function() {
+    var items = [{foo: 'bar', 54: 21}],
+        dest = [{foo: 'baz', 54: 33}];
+
+    GridList.cloneItems(items, dest);
+
+    expect(dest).toEqual(items);
+  });
+});

--- a/spec/gridPositioningSpec.js
+++ b/spec/gridPositioningSpec.js
@@ -67,7 +67,7 @@ describe("Grid positioning", function() {
       {x: 0, y: 1, w: 1, h: 1},
       {x: 1, y: 0, w: 1, h: 2},
       {x: 2, y: 0, w: 1, h: 1}
-    ], {rows: 2});
+    ], {lanes: 2});
 
     grid.resizeGrid(3);
 

--- a/spec/matchers.js
+++ b/spec/matchers.js
@@ -38,8 +38,8 @@ exports.toEqualPositions = function(expected) {
     ensureItemSizes(expected);
     ensureItemSizes(actual);
     console.log('\n\n' +
-      'Expected: ' + (new GridList(expected, {rows: getMaxHeight(expected)})) +
-      'Actual: ' + (new GridList(actual, {rows: getMaxHeight(actual)})));
+      'Expected: ' + (new GridList(expected, {lanes: getMaxHeight(expected)})) +
+      'Actual: ' + (new GridList(actual, {lanes: getMaxHeight(actual)})));
 
     // Let Jasmine know which are the items that differ
     return JSON.stringify(actual[_failingItem]) +

--- a/src/gridList.js
+++ b/src/gridList.js
@@ -301,6 +301,16 @@ GridList.prototype = {
       var item = this.items[i];
 
       // This can happen only the first time items are checked.
+      // We need the property to have a value for all the items so that the
+      // `cloneItems` method will merge the properties properly. If we only set
+      // it to the items that need it then the following can happen:
+      //
+      // cloneItems([{id: 1, autoSize: true}, {id: 2}],
+      //            [{id: 2}, {id: 1, autoSize: true}]);
+      //
+      // will result in
+      //
+      // [{id: 1, autoSize: true}, {id: 2, autoSize: true}]
       if (item.autoSize === undefined) {
         item.autoSize = item.w === 0 || item.h === 0;
       }

--- a/src/gridList.js
+++ b/src/gridList.js
@@ -258,7 +258,7 @@ GridList.prototype = {
 
     for (var i = 0; i < initialItems.length; i++) {
       var item = this._getItemByAttribute(idAttribute,
-                                      initialItems[i][idAttribute]);
+                                          initialItems[i][idAttribute]);
 
       if (item.x !== initialItems[i].x ||
           item.y !== initialItems[i].y ||

--- a/src/gridList.js
+++ b/src/gridList.js
@@ -254,11 +254,12 @@ GridList.prototype = {
      * Since both their position and size can change, the items need an
      * additional identifier attribute to match them with their previous state
      */
-    var changedItems = [],
-        i,
-        item;
-    for (i = 0; i < initialItems.length; i++) {
-      item = this._getItemByAttribute(idAttribute, initialItems[i][idAttribute]);
+    var changedItems = [];
+
+    for (var i = 0; i < initialItems.length; i++) {
+      var item = this._getItemByAttribute(idAttribute,
+                                      initialItems[i][idAttribute]);
+
       if (item.x !== initialItems[i].x ||
           item.y !== initialItems[i].y ||
           item.w !== initialItems[i].w ||
@@ -266,6 +267,7 @@ GridList.prototype = {
         changedItems.push(item);
       }
     }
+
     return changedItems;
   },
 

--- a/src/gridList.js
+++ b/src/gridList.js
@@ -301,11 +301,11 @@ GridList.prototype = {
       var item = this.items[i];
 
       // This can happen only the first time items are checked.
-      if (item.autoHeight === undefined) {
-         item.autoHeight = item.w === 0 || item.h === 0;
+      if (item.autoSize === undefined) {
+        item.autoSize = item.w === 0 || item.h === 0;
       }
 
-      if (item.autoHeight) {
+      if (item.autoSize) {
         if (this._options.direction === 'horizontal') {
           item.h = this._options.lanes;
         } else {

--- a/src/gridList.js
+++ b/src/gridList.js
@@ -299,8 +299,8 @@ GridList.prototype = {
       var item = this.items[i];
 
       // This can happen only the first time items are checked.
-      if (item.w === 0 || item.h === 0) {
-        item.autoHeight = true;
+      if (item.autoHeight === undefined) {
+         item.autoHeight = item.w === 0 || item.h === 0;
       }
 
       if (item.autoHeight) {


### PR DESCRIPTION
Fixes #67

> - We need this function to be called later on in order to apply the
current number of lanes to the “flexible” item attr, but setting the
autoHeight field itself is only done once!
- In order to make sure autoHeight is never set after the first call,
we only set it when the attr is undefined, and set a boolean value in
either true or false case